### PR TITLE
Edited `man` for `blockCol`

### DIFF
--- a/R/lefser.R
+++ b/R/lefser.R
@@ -174,7 +174,9 @@ filterKruskal <- function(relab, group, p.value, method = method) {
 #' default "GROUP").
 #' @param blockCol character(1) Optional column name in `colData(relab)`
 #' indicating the blocks, usually a factor with two levels (e.g.,
-#' `c("adult", "senior")`; default NULL).
+#' `c("adult", "senior")`; default NULL), but can be more than two levels; 
+#' also, this is NOT a statistical blocking variable, lefser does not have 
+#' statistical blocking option.
 #' @param assay The i-th assay matrix in the `SummarizedExperiment` ('relab';
 #' default 1).
 #' @param trim.names Default is `FALSE`. If `TRUE`, this function extracts 

--- a/man/lefser.Rd
+++ b/man/lefser.Rd
@@ -40,7 +40,7 @@ default "GROUP").}
 \item{blockCol}{character(1) Optional column name in \code{colData(relab)}
 indicating the blocks, usually a factor with two levels but can be more 
 than two levels (e.g., \code{c("adult", "senior") also, this is NOT a statistical 
-blocking variable, lefser does not have an option for statistical blocking}; 
+blocking variable, lefser does not have statistical blocking option}; 
 default NULL).}
 
 \item{assay}{The i-th assay matrix in the \code{SummarizedExperiment} ('relab';

--- a/man/lefser.Rd
+++ b/man/lefser.Rd
@@ -38,10 +38,10 @@ groups, usually a factor with two levels (e.g., \code{c("cases", "controls")};
 default "GROUP").}
 
 \item{blockCol}{character(1) Optional column name in \code{colData(relab)}
-indicating the blocks, usually a factor with two levels but can be more 
-than two levels (e.g., \code{c("adult", "senior") also, this is NOT a statistical 
-blocking variable, lefser does not have statistical blocking option}; 
-default NULL).}
+indicating the blocks, usually a factor with two levels (e.g.,
+\code{c("adult", "senior")}; default NULL), but can be more than two levels;
+also, this is NOT a statistical blocking variable, lefser does not have
+statistical blocking option.}
 
 \item{assay}{The i-th assay matrix in the \code{SummarizedExperiment} ('relab';
 default 1).}

--- a/man/lefser.Rd
+++ b/man/lefser.Rd
@@ -38,8 +38,10 @@ groups, usually a factor with two levels (e.g., \code{c("cases", "controls")};
 default "GROUP").}
 
 \item{blockCol}{character(1) Optional column name in \code{colData(relab)}
-indicating the blocks, usually a factor with two levels (e.g.,
-\code{c("adult", "senior")}; default NULL).}
+indicating the blocks, usually a factor with two levels but can be more 
+than two levels (e.g., \code{c("adult", "senior") also, this is NOT a statistical 
+blocking variable, lefser does not have an option for statistical blocking}; 
+default NULL).}
 
 \item{assay}{The i-th assay matrix in the \code{SummarizedExperiment} ('relab';
 default 1).}


### PR DESCRIPTION
Adding clarity/explanation to `man` for `blockCol`, explaining that this variable is usually two levels but can be more than two levels, and that `blockCol` argument is not a statistical blocking variable (`lefser` doesn't have a statistical blocking option). 