### PR TITLE
Allow all ranks in lefserClades and improve messaging about dropping tips

### DIFF
--- a/inst/scripts/cladogramPlot.R
+++ b/inst/scripts/cladogramPlot.R
@@ -12,19 +12,26 @@ tn <- get_terminal_nodes(rownames(z14))
 z14_tn <- z14[tn, ]
 z14_tn_ra <- relativeAb(z14_tn)
 z14_input <- rowNames2RowData(z14_tn_ra)
-
 res_z14_cld <- lefserClades(relab = z14_input, classCol = "study_condition")
-head(res_z14_cld)
-ggt <- lefserPlotClad(res_z14_cld, showNodeLabels = "g")
-ggt
-
 
 ## Example 2 - OTUs
 ## Clades will be summarized at the genus level and above
 tse <- getBenchmarkData("HMP_2012_16S_gingival_V35", dryrun = FALSE)[[1]]
 tse_ra <- relativeAb(tse)
 res_tse_cld <- lefserClades(relab = tse_ra, classCol = "body_subsite")
-ggt2 <- lefserPlotClad(res_tse_cld, showNodeLabels = "g")
-ggt2
 
-sessioninfo::session_info()
+
+
+
+
+# head(res_z14_cld)
+# ggt <- lefserPlotClad(res_z14_cld)
+# ggt
+
+# ggt2 <- lefserPlotClad(
+#     res_tse_cld, showTipLabels = TRUE, showNodeLabels = c("p", "c")
+# )
+# ggt2
+
+# sessioninfo::session_info()
+

--- a/man/lefserClades.Rd
+++ b/man/lefserClades.Rd
@@ -33,7 +33,7 @@ z14tn <- z14[tn, ]
 z14tn_ra <- relativeAb(z14tn)
 z14_input <- rowNames2RowData(z14tn_ra)
 
-resAll <- lefserClades(relab = z14_input, classCol = "study_condition")
-head(resAll)
+resCl <- lefserClades(relab = z14_input, classCol = "study_condition")
+head(Cl)
 
 }

--- a/man/lefserPlotClad.Rd
+++ b/man/lefserPlotClad.Rd
@@ -18,8 +18,8 @@ This argument also accepts a character(2) with two color names.}
 
 \item{showNodeLabels}{Label's to be shown in the tree.
 Options: "p" = phylum, "c" = class, "o" = order,
-"f" = family, "g" = genus. It can accept several options, e.g.,
-c("p", "c").}
+"f" = family, "g" = genus, "s" = species, "t" = strain.
+It can accept several options, e.g., c("p", "c").}
 }
 \value{
 A ggtree object.
@@ -34,6 +34,6 @@ z14 <- zeller14[, zeller14$study_condition != "adenoma"]
 tn <- get_terminal_nodes(rownames(z14))
 z14tn <- z14[tn, ]
 z14tn_ra <- relativeAb(z14tn)
-resAll <- lefserAllRanks(relab = z14tn_ra, classCol = "study_condition")
-ggt <- lefserPlotClad(df = resAll)
+resCl <- lefserClades(relab = z14tn_ra, classCol = "study_condition")
+ggt <- lefserPlotClad(df = resCl)
 }


### PR DESCRIPTION
@shbrief 

This PR addresses issue #71.

+ The restriction of species has been removed. The following taxonomic ranks are supported:
kingdom (k; superkingdom is converted to kingdom if present), phylum (p), class (c), order (o), family (f), genus (g) , species (s) , strain (t). These are the most common options and they're supported in the mia package.

+ Added  a more informative message when dropping leaves/tips/features. The number of features with missing information in mentioned for every rank.

``` r
suppressPackageStartupMessages({
    library(MicrobiomeBenchmarkData)
    library(lefser)
})

## Example 1 - Strains
## Clades will be summarized at the species level and above
data("zeller14")
z14 <- zeller14[, zeller14$study_condition %in% c("control", "CRC")]
tn <- get_terminal_nodes(rownames(z14))
z14_tn <- z14[tn, ]
z14_tn_ra <- relativeAb(z14_tn)
z14_input <- rowNames2RowData(z14_tn_ra)
res_z14_cld <- lefserClades(relab = z14_input, classCol = "study_condition")
#> 18 features don't have species information.
#> 96 features don't have strain information.
#> Dropped 96 features without full taxonomy information.
#> lefser will be run at the phylum, class, order, family, genus, species, strain level.
#> 
#> >>>> Running lefser at the phylum level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the class level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the order level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the family level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the genus level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the species level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the strain level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.

## Example 2 - OTUs
## Clades will be summarized at the genus level and above
tse <- getBenchmarkData("HMP_2012_16S_gingival_V35", dryrun = FALSE)[[1]]
#> Finished HMP_2012_16S_gingival_V35.
tse_ra <- relativeAb(tse)
res_tse_cld <- lefserClades(relab = tse_ra, classCol = "body_subsite")
#> 42 features don't have phylum information.
#> 96 features don't have class information.
#> 154 features don't have order information.
#> 666 features don't have family information.
#> 2023 features don't have genus information.
#> Dropped 2031 features without full taxonomy information.
#> Dropped 9 features with duplicated tip names.
#> lefser will be run at the phylum, class, order, family, genus level.
#> 
#> >>>> Running lefser at the phylum level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the class level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the order level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the family level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the genus level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
```

<sup>Created on 2024-10-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
