### PR TITLE
Fix geom point scale in legend for cladogram plot

### DIFF
--- a/R/lefserPlotClad.R
+++ b/R/lefserPlotClad.R
@@ -82,12 +82,15 @@ lefserPlotClad <- function(
     )
     nodLabRgx <- paste0("[", paste0(nodLab, collapse = ""), "]__")
     treeData <- dat |>
+        dplyr::mutate(abs = round(.data$abs, 1)) |> 
         dplyr::mutate(
             showNodeLabs = dplyr::case_when(
                 grepl(nodLabRgx, features) ~ features,
                 TRUE ~ NA
             )
         )
+    minval <- floor(min(treeData$abs, na.rm = TRUE))
+    maxval <- floor(max(treeData$abs, na.rm = TRUE))
     
     gt <- ggtree::ggtree(
         tree, layout = "circular",  branch.length = "none", size = 0.2
@@ -120,7 +123,14 @@ lefserPlotClad <- function(
             values = colors, breaks = c(controlVar, caseVar),
             name = "Sample", na.value = NA
         ) +
-        ggplot2::scale_size(name = "Absolute\nscore") +
+        ggplot2::scale_size(
+            name = "Absolute\nLDA score",
+            limits = c(minval, maxval),
+            # range = range(seq_along(seq(minval, maxval, 1))),
+            range = c(minval, maxval),
+            breaks = seq(minval, maxval, 1)
+            
+        ) +
         ggtree::theme(legend.position = "right")
     
     for (i in collapseThem) {

--- a/inst/scripts/cladogramPlot.R
+++ b/inst/scripts/cladogramPlot.R
@@ -14,7 +14,7 @@ z14_tn_ra <- relativeAb(z14_tn)
 z14_input <- rowNames2RowData(z14_tn_ra)
 
 resCl <- lefserClades(relab = z14_input, classCol = "study_condition")
-lefserPlotFeat(resCl, resCl$features[[22]])
+(ggt <- lefserPlotClad(resCl))
 
 ## Example 2 - OTUs
 ## Clades will be summarized at the genus level and above
@@ -22,6 +22,6 @@ tse <- getBenchmarkData("HMP_2012_16S_gingival_V35", dryrun = FALSE)[[1]]
 tse_ra <- relativeAb(tse)
 res_tse_cld <- lefserClades(relab = tse_ra, classCol = "body_subsite")
 
-lefserPlotFeat(res_tse_cld, res_tse_cld$features[[20]])
+(ggt2 <- lefserPlotClad(res_tse_cld))
 
 sessioninfo::session_info()


### PR DESCRIPTION
Fix the size of the points in the point size legend.

``` r
suppressPackageStartupMessages({
    library(MicrobiomeBenchmarkData)
    library(lefser)
})

## Example 1 - Strains
## Clades will be summarized at the species level and above
data("zeller14")
z14 <- zeller14[, zeller14$study_condition %in% c("control", "CRC")]
tn <- get_terminal_nodes(rownames(z14))
z14_tn <- z14[tn, ]
z14_tn_ra <- relativeAb(z14_tn)
z14_input <- rowNames2RowData(z14_tn_ra)

resCl <- lefserClades(relab = z14_input, classCol = "study_condition")
#> 18 features don't have species information.
#> 96 features don't have strain information.
#> Dropped 96 features without full taxonomy information.
#> lefser will be run at the kingdom, phylum, class, order, family, genus, species, strain level.
#> 
#> >>>> Running lefser at the kingdom level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the phylum level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the class level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the order level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the family level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the genus level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the species level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the strain level. <<<<
#> The outcome variable is specified as 'study_condition' and the reference category is 'control'.
#>  See `?factor` or `?relevel` to change the reference category.
(ggt <- lefserPlotClad(resCl))
#> Using palette: colorblind
```

![](https://i.imgur.com/HR168Ju.png)<!-- -->

``` r

## Example 2 - OTUs
## Clades will be summarized at the genus level and above
tse <- getBenchmarkData("HMP_2012_16S_gingival_V35", dryrun = FALSE)[[1]]
#> Finished HMP_2012_16S_gingival_V35.
tse_ra <- relativeAb(tse)
res_tse_cld <- lefserClades(relab = tse_ra, classCol = "body_subsite")
#> superkingdom --> kingdom
#> 42 features don't have phylum information.
#> 96 features don't have class information.
#> 154 features don't have order information.
#> 666 features don't have family information.
#> 2023 features don't have genus information.
#> Dropped 2031 features without full taxonomy information.
#> Dropped 9 features with duplicated tip names.
#> lefser will be run at the kingdom, phylum, class, order, family, genus level.
#> 
#> >>>> Running lefser at the kingdom level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the phylum level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the class level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the order level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the family level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.
#> 
#> >>>> Running lefser at the genus level. <<<<
#> The outcome variable is specified as 'body_subsite' and the reference category is 'subgingival_plaque'.
#>  See `?factor` or `?relevel` to change the reference category.

(ggt2 <- lefserPlotClad(res_tse_cld))
#> Using palette: colorblind
```

![](https://i.imgur.com/reA8Xfy.png)<!-- -->

``` r

sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.4.0 (2024-04-24)
#>  os       Pop!_OS 22.04 LTS
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/New_York
#>  date     2024-10-08
#>  pandoc   3.2 @ /usr/lib/rstudio/resources/app/bin/quarto/bin/tools/x86_64/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package                  * version  date (UTC) lib source
#>  abind                      1.4-8    2024-09-12 [1] CRAN (R 4.4.0)
#>  ape                        5.8      2024-04-11 [1] RSPM (R 4.4.0)
#>  aplot                      0.2.3    2024-06-17 [1] RSPM (R 4.4.0)
#>  backports                  1.5.0    2024-05-23 [1] RSPM (R 4.4.0)
#>  base64enc                  0.1-3    2015-07-28 [1] RSPM (R 4.4.0)
#>  beachmat                   2.21.6   2024-09-05 [1] Bioconductor 3.20 (R 4.4.0)
#>  beeswarm                   0.4.0    2021-06-01 [1] RSPM (R 4.4.0)
#>  Biobase                  * 2.65.1   2024-08-28 [1] Bioconductor 3.20 (R 4.4.0)
#>  BiocFileCache              2.13.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  BiocGenerics             * 0.51.2   2024-09-27 [1] Bioconductor 3.20 (R 4.4.0)
#>  BiocNeighbors              1.99.1   2024-09-22 [1] Bioconductor 3.20 (R 4.4.0)
#>  BiocParallel               1.39.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  BiocSingular               1.21.4   2024-09-22 [1] Bioconductor 3.20 (R 4.4.0)
#>  Biostrings               * 2.73.2   2024-09-26 [1] Bioconductor 3.20 (R 4.4.0)
#>  bit                        4.5.0    2024-09-20 [1] RSPM (R 4.4.0)
#>  bit64                      4.5.2    2024-09-22 [1] RSPM (R 4.4.0)
#>  blob                       1.2.4    2023-03-17 [1] RSPM (R 4.4.0)
#>  bluster                    1.15.1   2024-09-06 [1] Bioconductor 3.20 (R 4.4.0)
#>  boot                       1.3-31   2024-08-28 [2] RSPM (R 4.4.0)
#>  brio                       1.1.5    2024-04-24 [1] RSPM (R 4.4.0)
#>  cachem                     1.1.0    2024-05-16 [1] RSPM (R 4.4.0)
#>  checkmate                  2.3.2    2024-07-29 [1] RSPM (R 4.4.0)
#>  cli                        3.6.3    2024-06-21 [1] RSPM (R 4.4.0)
#>  cluster                    2.1.6    2023-12-01 [2] CRAN (R 4.4.0)
#>  codetools                  0.2-20   2024-03-31 [2] CRAN (R 4.4.0)
#>  coin                       1.4-3    2023-09-27 [1] RSPM (R 4.4.0)
#>  colorspace                 2.1-1    2024-07-26 [1] RSPM (R 4.4.0)
#>  crayon                     1.5.3    2024-06-20 [1] RSPM (R 4.4.0)
#>  curl                       5.2.3    2024-09-20 [1] RSPM (R 4.4.0)
#>  data.table                 1.16.0   2024-08-27 [1] RSPM (R 4.4.0)
#>  DBI                        1.2.3    2024-06-02 [1] RSPM (R 4.4.0)
#>  dbplyr                     2.5.0    2024-03-19 [1] RSPM (R 4.4.0)
#>  DECIPHER                   3.1.4    2024-06-12 [1] Bioconductor 3.20 (R 4.4.0)
#>  decontam                   1.25.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  DelayedArray               0.31.12  2024-09-27 [1] Bioconductor 3.20 (R 4.4.0)
#>  DelayedMatrixStats         1.27.3   2024-08-08 [1] Bioconductor 3.20 (R 4.4.0)
#>  digest                     0.6.37   2024-08-19 [1] RSPM (R 4.4.0)
#>  DirichletMultinomial       1.47.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  dplyr                      1.1.4    2023-11-17 [1] RSPM (R 4.4.0)
#>  evaluate                   1.0.0    2024-09-17 [1] CRAN (R 4.4.0)
#>  fansi                      1.0.6    2023-12-08 [1] RSPM (R 4.4.0)
#>  farver                     2.1.2    2024-05-13 [1] RSPM (R 4.4.0)
#>  fastmap                    1.2.0    2024-05-15 [1] RSPM (R 4.4.0)
#>  filelock                   1.0.3    2023-12-11 [1] RSPM (R 4.4.0)
#>  foreign                    0.8-87   2024-06-26 [2] RSPM (R 4.4.0)
#>  Formula                    1.2-5    2023-02-24 [1] RSPM (R 4.4.0)
#>  fs                         1.6.4    2024-04-25 [1] RSPM (R 4.4.0)
#>  generics                   0.1.3    2022-07-05 [1] RSPM (R 4.4.0)
#>  GenomeInfoDb             * 1.41.1   2024-05-24 [1] Bioconductor 3.20 (R 4.4.0)
#>  GenomeInfoDbData           1.2.13   2024-10-02 [1] Bioconductor
#>  GenomicRanges            * 1.57.1   2024-06-12 [1] Bioconductor 3.20 (R 4.4.0)
#>  ggbeeswarm                 0.7.2    2023-04-29 [1] RSPM (R 4.4.0)
#>  ggfun                      0.1.6    2024-08-28 [1] RSPM (R 4.4.0)
#>  ggplot2                    3.5.1    2024-04-23 [1] RSPM (R 4.4.0)
#>  ggplotify                  0.1.2    2023-08-09 [1] RSPM (R 4.4.0)
#>  ggrepel                    0.9.6    2024-09-07 [1] RSPM (R 4.4.0)
#>  ggtree                     3.13.1   2024-08-18 [1] Bioconductor 3.20 (R 4.4.0)
#>  glue                       1.8.0    2024-09-30 [1] RSPM (R 4.4.0)
#>  gridExtra                  2.3      2017-09-09 [1] RSPM (R 4.4.0)
#>  gridGraphics               0.5-1    2020-12-13 [1] RSPM (R 4.4.0)
#>  gtable                     0.3.5    2024-04-22 [1] RSPM (R 4.4.0)
#>  Hmisc                      5.1-3    2024-05-28 [1] RSPM (R 4.4.0)
#>  htmlTable                  2.4.3    2024-07-21 [1] RSPM (R 4.4.0)
#>  htmltools                  0.5.8.1  2024-04-04 [1] RSPM (R 4.4.0)
#>  htmlwidgets                1.6.4    2023-12-06 [1] RSPM (R 4.4.0)
#>  httr                       1.4.7    2023-08-15 [1] RSPM (R 4.4.0)
#>  igraph                     2.0.3    2024-03-13 [1] RSPM (R 4.4.0)
#>  IRanges                  * 2.39.2   2024-07-17 [1] Bioconductor 3.20 (R 4.4.0)
#>  irlba                      2.3.5.1  2022-10-03 [1] RSPM (R 4.4.0)
#>  jsonlite                   1.8.9    2024-09-20 [1] RSPM (R 4.4.0)
#>  knitr                      1.48     2024-07-07 [1] RSPM (R 4.4.0)
#>  labeling                   0.4.3    2023-08-29 [1] RSPM (R 4.4.0)
#>  lattice                    0.22-6   2024-03-20 [2] CRAN (R 4.4.0)
#>  lazyeval                   0.2.2    2019-03-15 [1] RSPM (R 4.4.0)
#>  lefser                   * 1.15.9   2024-10-08 [1] Bioconductor
#>  libcoin                    1.0-10   2023-09-27 [1] RSPM (R 4.4.0)
#>  lifecycle                  1.0.4    2023-11-07 [1] RSPM (R 4.4.0)
#>  lme4                       1.1-35.5 2024-07-03 [1] RSPM (R 4.4.0)
#>  lpSolve                    5.6.21   2024-09-12 [1] CRAN (R 4.4.0)
#>  magrittr                   2.0.3    2022-03-30 [1] RSPM (R 4.4.0)
#>  MASS                       7.3-61   2024-06-13 [2] RSPM (R 4.4.0)
#>  Matrix                     1.7-0    2024-03-22 [2] CRAN (R 4.4.0)
#>  MatrixGenerics           * 1.17.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  matrixStats              * 1.4.1    2024-09-08 [1] RSPM (R 4.4.0)
#>  mediation                  4.5.0    2019-10-08 [1] RSPM (R 4.4.0)
#>  memoise                    2.0.1    2021-11-26 [1] RSPM (R 4.4.0)
#>  mgcv                       1.9-1    2023-12-21 [2] CRAN (R 4.4.0)
#>  mia                        1.13.36  2024-08-28 [1] Bioconductor 3.20 (R 4.4.0)
#>  MicrobiomeBenchmarkData  * 1.7.1    2024-09-03 [1] Bioconductor 3.20 (R 4.4.0)
#>  minqa                      1.2.8    2024-08-17 [1] RSPM (R 4.4.0)
#>  modeltools                 0.2-23   2020-03-05 [1] RSPM (R 4.4.0)
#>  multcomp                   1.4-26   2024-07-18 [1] RSPM (R 4.4.0)
#>  MultiAssayExperiment       1.31.5   2024-08-23 [1] Bioconductor 3.20 (R 4.4.0)
#>  munsell                    0.5.1    2024-04-01 [1] RSPM (R 4.4.0)
#>  mvtnorm                    1.3-1    2024-09-03 [1] RSPM (R 4.4.0)
#>  nlme                       3.1-166  2024-08-14 [1] RSPM (R 4.4.0)
#>  nloptr                     2.1.1    2024-06-25 [1] RSPM (R 4.4.0)
#>  nnet                       7.3-19   2023-05-03 [2] CRAN (R 4.4.0)
#>  patchwork                  1.3.0    2024-09-16 [1] CRAN (R 4.4.0)
#>  permute                    0.9-7    2022-01-27 [1] RSPM (R 4.4.0)
#>  pillar                     1.9.0    2023-03-22 [1] RSPM (R 4.4.0)
#>  pkgconfig                  2.0.3    2019-09-22 [1] RSPM (R 4.4.0)
#>  plyr                       1.8.9    2023-10-02 [1] RSPM (R 4.4.0)
#>  purrr                      1.0.2    2023-08-10 [1] RSPM (R 4.4.0)
#>  R6                         2.5.1    2021-08-19 [1] RSPM (R 4.4.0)
#>  rbiom                      1.0.3    2021-11-05 [1] RSPM (R 4.4.0)
#>  Rcpp                       1.0.13   2024-07-17 [1] RSPM (R 4.4.0)
#>  RcppParallel               5.1.9    2024-08-19 [1] RSPM (R 4.4.0)
#>  reprex                     2.1.1    2024-07-06 [1] CRAN (R 4.4.0)
#>  reshape2                   1.4.4    2020-04-09 [1] RSPM (R 4.4.0)
#>  rlang                      1.1.4    2024-06-04 [1] RSPM (R 4.4.0)
#>  rmarkdown                  2.28     2024-08-17 [1] RSPM (R 4.4.0)
#>  rpart                      4.1.23   2023-12-05 [2] CRAN (R 4.4.0)
#>  RSQLite                    2.3.7    2024-05-27 [1] RSPM (R 4.4.0)
#>  rstudioapi                 0.16.0   2024-03-24 [1] RSPM (R 4.4.0)
#>  rsvd                       1.0.5    2021-04-16 [1] RSPM (R 4.4.0)
#>  S4Arrays                   1.5.10   2024-09-29 [1] Bioconductor 3.20 (R 4.4.0)
#>  S4Vectors                * 0.43.2   2024-07-17 [1] Bioconductor 3.20 (R 4.4.0)
#>  sandwich                   3.1-1    2024-09-15 [1] CRAN (R 4.4.0)
#>  ScaledMatrix               1.13.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  scales                     1.3.0    2023-11-28 [1] RSPM (R 4.4.0)
#>  scater                     1.33.4   2024-07-21 [1] Bioconductor 3.20 (R 4.4.0)
#>  scuttle                    1.15.4   2024-08-14 [1] Bioconductor 3.20 (R 4.4.0)
#>  sessioninfo                1.2.2    2021-12-06 [1] RSPM (R 4.4.0)
#>  SingleCellExperiment     * 1.27.2   2024-05-24 [1] Bioconductor 3.20 (R 4.4.0)
#>  slam                       0.1-53   2024-09-02 [1] RSPM (R 4.4.0)
#>  SparseArray                1.5.41   2024-09-27 [1] Bioconductor 3.20 (R 4.4.0)
#>  sparseMatrixStats          1.17.2   2024-06-12 [1] Bioconductor 3.20 (R 4.4.0)
#>  stringi                    1.8.4    2024-05-06 [1] RSPM (R 4.4.0)
#>  stringr                    1.5.1    2023-11-14 [1] RSPM (R 4.4.0)
#>  SummarizedExperiment     * 1.35.2   2024-09-27 [1] Bioconductor 3.20 (R 4.4.0)
#>  survival                   3.7-0    2024-06-05 [2] RSPM (R 4.4.0)
#>  testthat                   3.2.1.1  2024-04-14 [1] RSPM (R 4.4.0)
#>  TH.data                    1.1-2    2023-04-17 [1] RSPM (R 4.4.0)
#>  tibble                     3.2.1    2023-03-20 [1] RSPM (R 4.4.0)
#>  tidyr                      1.3.1    2024-01-24 [1] RSPM (R 4.4.0)
#>  tidyselect                 1.2.1    2024-03-11 [1] RSPM (R 4.4.0)
#>  tidytree                   0.4.6    2023-12-12 [1] RSPM (R 4.4.0)
#>  treeio                     1.29.1   2024-08-18 [1] Bioconductor 3.20 (R 4.4.0)
#>  TreeSummarizedExperiment * 2.13.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  UCSC.utils                 1.1.0    2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  utf8                       1.2.4    2023-10-22 [1] RSPM (R 4.4.0)
#>  vctrs                      0.6.5    2023-12-01 [1] RSPM (R 4.4.0)
#>  vegan                      2.6-8    2024-08-28 [1] RSPM (R 4.4.0)
#>  vipor                      0.4.7    2023-12-18 [1] RSPM (R 4.4.0)
#>  viridis                    0.6.5    2024-01-29 [1] RSPM (R 4.4.0)
#>  viridisLite                0.4.2    2023-05-02 [1] RSPM (R 4.4.0)
#>  withr                      3.0.1    2024-07-31 [1] RSPM (R 4.4.0)
#>  xfun                       0.47     2024-08-17 [1] RSPM (R 4.4.0)
#>  XVector                  * 0.45.0   2024-05-01 [1] Bioconductor 3.20 (R 4.4.0)
#>  yaml                       2.3.10   2024-07-26 [1] RSPM (R 4.4.0)
#>  yulab.utils                0.1.7    2024-08-26 [1] RSPM (R 4.4.0)
#>  zlibbioc                   1.51.1   2024-06-05 [1] Bioconductor 3.20 (R 4.4.0)
#>  zoo                        1.8-12   2023-04-13 [1] RSPM (R 4.4.0)
#> 
#>  [1] /home/user/R/x86_64-pc-linux-gnu-library/4.4
#>  [2] /home/user/apps/R-4.4.0/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

<sup>Created on 2024-10-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
