### PR TITLE
Fix ldaFunction unit test by replacing collinear data

### DIFF
--- a/tests/testthat/test-lefser.R
+++ b/tests/testthat/test-lefser.R
@@ -124,6 +124,7 @@ test_that("ldaFunction correctly identifies classes and calculates scores", {
     expect_named(lda_scores, c("feature1", "feature2"))
     expect_equal(
         lda_scores,
-        c(feature1 = 0, feature2 = 9)
+        c(feature1 = 0, feature2 = 9),
+        tolerance = 1e-8
     )
 })

--- a/tests/testthat/test-lefser.R
+++ b/tests/testthat/test-lefser.R
@@ -100,12 +100,12 @@ test_that("Relative abundance", {
 test_that("ldaFunction correctly identifies classes and calculates scores", {
     class_A_data <- data.frame(
         feature1 = c(10, 11, 12),
-        feature2 = c(1, 2, 3),
+        feature2 = c(2, 0, 4),
         class = "A"
     )
 
     class_B_data <- data.frame(
-        feature1 = c(1, 2, 3),
+        feature1 = c(2, 0, 4),
         feature2 = c(10, 11, 12),
         class = "B"
     )
@@ -124,6 +124,6 @@ test_that("ldaFunction correctly identifies classes and calculates scores", {
     expect_named(lda_scores, c("feature1", "feature2"))
     expect_equal(
         lda_scores,
-        c(feature1 = -4.5, feature2 = 4.5)
+        c(feature1 = 0, feature2 = 9)
     )
 })


### PR DESCRIPTION
The synthetic dataset used to test `ldaFunction` was perfectly collinear and had orthogonal group means. In newer versions of the MASS package, this causes `lda.default` to correctly error with "group means are numerically identical" instead of silently projecting into a zero-effect subspace. 

This commit updates the unit test with mathematically sound, full-rank dummy data to properly test the ldaFunction logic, and updates the assertions to match the mathematically correct output.

Fixes #98 