### PR TITLE
Fix testing error and test data loading

### DIFF
--- a/R/lefserPlot.R
+++ b/R/lefserPlot.R
@@ -93,7 +93,7 @@ lefserPlot <- function(
             stat = "identity",
             aes(fill = class),
             color = "black",
-            size = 0.3
+            linewidth = 0.3
         ) +
         theme(
             # Legends

--- a/tests/testthat/helper-data.R
+++ b/tests/testthat/helper-data.R
@@ -1,0 +1,5 @@
+load_lefser_dataset <- function(name) {
+    dataenv <- new.env(parent = emptyenv())
+    utils::data(list = name, package = "lefser", envir = dataenv)
+    dataenv[[name]]
+}

--- a/tests/testthat/test-lefser.R
+++ b/tests/testthat/test-lefser.R
@@ -3,9 +3,7 @@ checkEnding <- function(resObj, index, column, value) {
 }
 
 library(lefser)
-dataenv <- new.env(parent = emptyenv())
-data("zeller14", package = "lefser", envir = dataenv)
-zeller14 <- dataenv[["zeller14"]]
+zeller14 <- load_lefser_dataset("zeller14")
 zeller142 <- zeller14[, zeller14$study_condition != "adenoma"]
 tn <- get_terminal_nodes(rownames(zeller142))
 zellersub <- zeller142[tn, ]

--- a/tests/testthat/test-lefserPlotClad.R
+++ b/tests/testthat/test-lefserPlotClad.R
@@ -1,4 +1,8 @@
-data("zeller14")
+library(lefser)
+dataenv <- new.env(parent = emptyenv())
+data("zeller14", package = "lefser", envir = dataenv)
+zeller14 <- dataenv[["zeller14"]]
+
 z14 <- zeller14[, zeller14$study_condition != "adenoma"]
 tn <- get_terminal_nodes(rownames(z14))
 z14tn <- z14[tn, ]

--- a/tests/testthat/test-lefserPlotClad.R
+++ b/tests/testthat/test-lefserPlotClad.R
@@ -1,7 +1,5 @@
 library(lefser)
-dataenv <- new.env(parent = emptyenv())
-data("zeller14", package = "lefser", envir = dataenv)
-zeller14 <- dataenv[["zeller14"]]
+zeller14 <- load_lefser_dataset("zeller14")
 
 z14 <- zeller14[, zeller14$study_condition != "adenoma"]
 tn <- get_terminal_nodes(rownames(z14))

--- a/tests/testthat/test-lefserPlotFeat.R
+++ b/tests/testthat/test-lefserPlotFeat.R
@@ -1,5 +1,8 @@
+library(lefser)
+dataenv <- new.env(parent = emptyenv())
+data("zeller14", package = "lefser", envir = dataenv)
+zeller14 <- dataenv[["zeller14"]]
 
-data(zeller14)
 zeller14 <- zeller14[, zeller14$study_condition != "adenoma"]
 tn <- get_terminal_nodes(rownames(zeller14))
 zeller14tn <- zeller14[tn,]

--- a/tests/testthat/test-lefserPlotFeat.R
+++ b/tests/testthat/test-lefserPlotFeat.R
@@ -1,7 +1,5 @@
 library(lefser)
-dataenv <- new.env(parent = emptyenv())
-data("zeller14", package = "lefser", envir = dataenv)
-zeller14 <- dataenv[["zeller14"]]
+zeller14 <- load_lefser_dataset("zeller14")
 
 zeller14 <- zeller14[, zeller14$study_condition != "adenoma"]
 tn <- get_terminal_nodes(rownames(zeller14))


### PR DESCRIPTION
This PR fixes a testing error caught by GitHub actions where `lefserPlot()` was throwing a warning because `size` in `geom_bar` is deprecated in favor of `linewidth` in recent `ggplot2` versions. It also safely loads `zeller14` in unit tests to ensure `covr::package_coverage()` works smoothly in CI.